### PR TITLE
Type infrared intensity results

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,47 +1,46 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches:
       - main
       - develop
   pull_request:
-    branches: 
-      - '*'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        julia_version:
+          - '1.10'
+          - '1'
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: build package
-        uses: julia-actions/julia-buildpkg@latest
-        
-      - name: install dependencies
-        run: julia --project --color=yes -e 'import Pkg; Pkg.add.(["Documenter", "Coverage"])'
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia_version }}
 
-      - name: test # run the unit tests
-        run: julia --project --color=yes --code-coverage -e 'import Pkg; Pkg.test(coverage=true)'
-        
-      - name: process test coverage
+      - uses: julia-actions/cache@v1
+
+      - name: Build package
+        uses: julia-actions/julia-buildpkg@v1
+
+      - name: Run tests
+        run: julia --project=. --color=yes --code-coverage=user -e 'import Pkg; Pkg.test(coverage=true)'
+
+      - name: Process coverage
+        if: matrix.julia_version == '1'
         uses: julia-actions/julia-processcoverage@v1
-        
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+
+      - name: Upload coverage
+        if: matrix.julia_version == '1'
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-                

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,13 @@ version = "0.3.1"
 Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Comonicon = "1"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.05%
+
 ignore:
   - "src/main.jl"

--- a/src/main.jl
+++ b/src/main.jl
@@ -24,7 +24,7 @@ Calculate the wavenumbers, intensities, force constants, reduced masses and eige
 - `--modes`: Write the modes in xyz format. If not specified, the modes will not be written.
 
 """
-@main function vibrationalanalalysis(restart::String, hessian::String; unit = "kcal", moldescriptor = nothing, output = nothing, normal_modes = nothing, modes::Bool = false)
+Comonicon.@main function vibrationalanalysis(restart::String, hessian::String; unit = "kcal", moldescriptor = nothing, output = nothing, normal_modes = nothing, modes::Bool = false)
 
 	# Check if the unit is valid
 	wavenumber = check_unit(unit)

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -115,9 +115,9 @@ Calculate the infrared intensity in km mol^-1 from the normalization eigen matri
 """
 function infrared_intensity(eigenvectors_internal_normalized::Matrix{Float64}, atom_charges::Vector{Float64}, reduced_masses::Vector{Float64})
 
-	intensities = []
+	intensities = Vector{Float64}(undef, size(eigenvectors_internal_normalized, 2))
 
-	for i in 1:size(eigenvectors_internal_normalized)[1]
+	for i in axes(eigenvectors_internal_normalized, 2)
 
 		# Eigenvector of the i-th mode
 		eigenvector = reshape(eigenvectors_internal_normalized[:, i], 3, :)'
@@ -125,7 +125,7 @@ function infrared_intensity(eigenvectors_internal_normalized::Matrix{Float64}, a
 		# Conversion factor taken from: http://thiele.ruc.dk/~spanget/help/g09/k_constants.html
 		intensity = sum((sum(eigenvector .* atom_charges, dims = 1) / 0.2081943 / norm(eigenvector)) .^ 2 / reduced_masses[i] * 42.2561)
 
-		push!(intensities, intensity)
+		intensities[i] = intensity
 	end
 
 	return intensities

--- a/test/calculate.jl
+++ b/test/calculate.jl
@@ -3,19 +3,19 @@
 	hessian = read_hessian("data/test_hessian_h2o.dat")
 	atom_charges = read_moldescriptor("data/test_moldescriptor.dat", atom_names, atom_types)
 	wavenumbers, intensities, force_constants, reduced_masses = calculate(atom_masses, atom_coords, atom_charges, hessian)
-	@test wavenumbers[7:end] ≈ [1492.5104569439752, 3669.03923547886, 3784.390612155495] atol = 1e-5
-	@test intensities[7:end] ≈ [150.52494226058752, 86.42940396506292, 164.0700800418807] atol = 1e-5
-	@test force_constants[7:end] ≈ [1.4173086016921352, 8.312559679465139, 9.171054294242243] atol = 1e-5
-	@test reduced_masses[7:end] ≈ [1.0798645051916647, 1.0480202469197442, 1.086843369500246] atol = 1e-5
+	@test wavenumbers[7:end] ≈ [1492.5104569439752, 3669.03923547886, 3784.390612155495] atol = 1e-5 rtol = 1e-8
+	@test intensities[7:end] ≈ [150.52494226058752, 86.42940396506292, 164.0700800418807] atol = 1e-5 rtol = 1e-8
+	@test force_constants[7:end] ≈ [1.4173086016921352, 8.312559679465139, 9.171054294242243] atol = 1e-5 rtol = 1e-8
+	@test reduced_masses[7:end] ≈ [1.0798645051916647, 1.0480202469197442, 1.086843369500246] atol = 1e-5 rtol = 1e-8
 end
 
 @testset "Read Files and Calculate VibAnal - No Intensities" begin
 	atom_names, atom_masses, atom_coords, atom_types = read_rst("data/test_h2o.rst")
 	hessian = read_hessian("data/test_hessian_h2o.dat")
 	wavenumbers, force_constants, reduced_masses = calculate(atom_masses, atom_coords, hessian)
-	@test wavenumbers[7:end] ≈ [1492.5104569439752, 3669.03923547886, 3784.390612155495] atol = 1e-5
-	@test force_constants[7:end] ≈ [1.4173086016921352, 8.312559679465139, 9.171054294242243] atol = 1e-5
-	@test reduced_masses[7:end] ≈ [1.0798645051916647, 1.0480202469197442, 1.086843369500246] atol = 1e-5
+	@test wavenumbers[7:end] ≈ [1492.5104569439752, 3669.03923547886, 3784.390612155495] atol = 1e-5 rtol = 1e-8
+	@test force_constants[7:end] ≈ [1.4173086016921352, 8.312559679465139, 9.171054294242243] atol = 1e-5 rtol = 1e-8
+	@test reduced_masses[7:end] ≈ [1.0798645051916647, 1.0480202469197442, 1.086843369500246] atol = 1e-5 rtol = 1e-8
 end
 
 @testset "Normal Modes - H2O" begin

--- a/test/observables.jl
+++ b/test/observables.jl
@@ -1,4 +1,4 @@
-using VibrationalAnalysis: wavenumber_hartree, wavenumber_eV, wavenumber_kcal, reduced_mass, force_constant
+using VibrationalAnalysis: wavenumber_hartree, wavenumber_eV, wavenumber_kcal, reduced_mass, force_constant, infrared_intensity
 using Test
 
 @testset "Wave Number hartree" begin
@@ -28,3 +28,17 @@ end
 
 end
 
+@testset "Infrared Intensity" begin
+    eigenvectors = [
+        1.0 0.0
+        0.0 1.0
+        0.0 0.0
+        0.0 0.0
+        0.0 0.0
+        0.0 0.0
+    ]
+    intensities = infrared_intensity(eigenvectors, [1.0, -1.0], [1.0, 2.0])
+
+    @test intensities isa Vector{Float64}
+    @test length(intensities) == 2
+end


### PR DESCRIPTION
## Summary
- return `Vector{Float64}` from `infrared_intensity`
- iterate over mode columns explicitly instead of relying on the first matrix dimension
- add a direct test for the typed intensity result

## Validation
- `/Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.test()'` on Julia 1.12.6
- `/Users/jog/.juliaup/bin/julia +1.10 --project=. --color=yes -e 'import Pkg; Pkg.test()'` on Julia 1.10.11

This is stacked on #23.
