### PR TITLE
Fix vibrational edge cases

### DIFF
--- a/src/VibrationalAnalysis.jl
+++ b/src/VibrationalAnalysis.jl
@@ -21,7 +21,7 @@ julia> calculate(atom_masses, atom_coords, atom_charges, hessian)
 Or directly perform a vibrational analysis with atom masses, atom coordinates, atom charges and hessian of the system.
 
 ```julia-repl
-julia> wavenumbers, intensities, _, _ = calculate(atom_masses, atom_coords, atom_charges, hessian)
+julia> wavenumbers, intensities, _, _, _ = calculate(atom_masses, atom_coords, atom_charges, hessian)
 julia> write_wavenumber_intensity(wavenumbers, intensities, filename="wavenumbers.dat")
 ```
 

--- a/src/calculate.jl
+++ b/src/calculate.jl
@@ -11,7 +11,8 @@ Calculates the wavenumbers, force constants and reduced masses from the atom mas
 - `hessian::Matrix{Float64}`: Matrix of the hessian (3nx3n)
 
 # Keyword Arguments
-- `wavenumber::Function`: The wavenumber function to use. Either `wavenumber_kcal`, `wavenumber_eV` or `wavenumber_hartree`. Default is `wavenumber_kcal`. 
+- `wavenumber::Function`: The wavenumber function to use. Either `wavenumber_kcal`, `wavenumber_eV` or `wavenumber_hartree`. Default is `wavenumber_kcal`.
+- `hessian_sign::Union{Symbol,Real}`: Hessian sign convention. Use `:auto`, `:positive`, `:negative`, `1`, or `-1`. Default is `:auto`.
 
 # Returns
 - `wavenumbers::Vector{Float64}`: The wavenumbers.
@@ -26,10 +27,11 @@ julia> calculate(atom_masses, atom_coords, hessian, wavenumber=wavenumber_hartre
 julia> calculate(atom_masses, atom_coords, hessian, wavenumber=wavenumber_eV)
 ```
 """
-function calculate(atom_masses::Vector{Float64}, atom_coords::Matrix{Float64}, hessian::Matrix{Float64}; wavenumber = wavenumber_kcal)
+function calculate(atom_masses::Vector{Float64}, atom_coords::Matrix{Float64}, hessian::Matrix{Float64}; wavenumber = wavenumber_kcal, hessian_sign = :auto)
 
 	# Symmetrize the hessian and mass weighting
-	hessian_mw = mass_weighted_hessian(hessian, atom_masses)
+	sign_factor = hessian_sign_factor(atom_coords, atom_masses, hessian, hessian_sign)
+	hessian_mw = mass_weighted_hessian(hessian, atom_masses, sign = sign_factor)
 
 	# Transform in internal coordinates
 	eigenvalues, eigenvectors_internal_normalized, normalization = internal_coordinates(atom_coords, atom_masses, hessian_mw)
@@ -54,7 +56,8 @@ Calculates the wavenumbers, intensities, force constants and reduced masses from
 - `hessian::Matrix{Float64}`: Matrix of the hessian (3nx3n)
 
 # Keyword Arguments
-- `wavenumber::Function`: The wavenumber function to use. Either `wavenumber_kcal`, `wavenumber_eV` or `wavenumber_hartree`. Default is `wavenumber_kcal`. 
+- `wavenumber::Function`: The wavenumber function to use. Either `wavenumber_kcal`, `wavenumber_eV` or `wavenumber_hartree`. Default is `wavenumber_kcal`.
+- `hessian_sign::Union{Symbol,Real}`: Hessian sign convention. Use `:auto`, `:positive`, `:negative`, `1`, or `-1`. Default is `:auto`.
 
 # Returns
 - `wavenumbers::Vector{Float64}`: The wavenumbers.
@@ -70,10 +73,11 @@ julia> calculate(atom_masses, atom_coords, atom_charges, hessian, wavenumber=wav
 julia> calculate(atom_masses, atom_coords, atom_charges, hessian, wavenumber=wavenumber_eV)
 ```
 """
-function calculate(atom_masses::Vector{Float64}, atom_coords::Matrix{Float64}, atom_charges::Vector{Float64}, hessian::Matrix{Float64}; wavenumber = wavenumber_kcal)
+function calculate(atom_masses::Vector{Float64}, atom_coords::Matrix{Float64}, atom_charges::Vector{Float64}, hessian::Matrix{Float64}; wavenumber = wavenumber_kcal, hessian_sign = :auto)
 
 	# Symmetrize the hessian and mass weighting
-	hessian_mw = mass_weighted_hessian(hessian, atom_masses)
+	sign_factor = hessian_sign_factor(atom_coords, atom_masses, hessian, hessian_sign)
+	hessian_mw = mass_weighted_hessian(hessian, atom_masses, sign = sign_factor)
 
 	# Transform in internal coordinates
 	eigenvalues, eigenvectors_internal_normalized, normalization = internal_coordinates(atom_coords, atom_masses, hessian_mw)
@@ -85,4 +89,40 @@ function calculate(atom_masses::Vector{Float64}, atom_coords::Matrix{Float64}, a
 	force_constants = force_constant(omega, reduced_masses)
 
 	return wavenumbers, intensities, force_constants, reduced_masses, eigenvectors_internal_normalized
+end
+
+function hessian_sign_factor(atom_coords::Matrix{Float64}, atom_masses::Vector{Float64}, hessian::Matrix{Float64}, hessian_sign)
+	if hessian_sign isa Real
+		if hessian_sign == 1 || hessian_sign == -1
+			return Float64(hessian_sign)
+		end
+	elseif hessian_sign == :positive
+		return 1.0
+	elseif hessian_sign == :negative
+		return -1.0
+	elseif hessian_sign == :auto
+		hessian_mw = mass_weighted_hessian(hessian, atom_masses, sign = 1.0)
+		subspace = internal_subspace(atom_coords, atom_masses)
+
+		if size(subspace, 2) == 0
+			return 1.0
+		end
+
+		eigenvalues = eigvals(Symmetric(subspace' * hessian_mw * subspace))
+		threshold = sqrt(eps(Float64)) * max(1.0, maximum(abs.(eigenvalues)))
+		positive_count = count(>(threshold), eigenvalues)
+		negative_count = count(<(-threshold), eigenvalues)
+
+		if negative_count > positive_count
+			return -1.0
+		elseif positive_count > negative_count
+			return 1.0
+		end
+
+		positive_weight = sum(abs, eigenvalues[eigenvalues .> threshold])
+		negative_weight = sum(abs, eigenvalues[eigenvalues .< -threshold])
+		return negative_weight > positive_weight ? -1.0 : 1.0
+	end
+
+	throw(ArgumentError("hessian_sign must be :auto, :positive, :negative, 1, or -1"))
 end

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -6,7 +6,7 @@ export wavenumber_hartree, wavenumber_eV, wavenumber_kcal
 Convert `eigenvalues` from hartree bohr^-2 g^-1 to `wavenumbers` in cm^-1. Made for DFTB hessian files.
 Output include `omega` in s^-2.
 
-``ω = √v``
+``ω = sign(v)√|v|``
 
 ``ν̃ = 1/(2π * c) * ω``
 
@@ -17,7 +17,7 @@ function wavenumber_hartree(eigenvalues::Vector{Float64})
 
 	# Conversion hartree bohr^-2 g^-1 to s^-2:
 	#   2625500.2 J/Hartree * (0.188972598857892E+11)^2 bohr^2 / m^2  * 1000 g / kg
-	omega = sqrt.(eigenvalues * 2625500.2 * (0.188972598857892E+11)^2 * 1000)
+	omega = signed_sqrt(eigenvalues * 2625500.2 * (0.188972598857892E+11)^2 * 1000)
 
 	# Convert wavenumbers in s^-2 to wavenumbers in cm^-1 : 1/(2π * c) * ω
 	wavenumbers = 1 / (2π * 2.99792458e10) * omega
@@ -31,7 +31,7 @@ end
 Convert `eigenvalues` from eV Å^-2 g^-1 to `wavenumbers` in cm^-1. Made for ASE hessian files.
 Output include `omega` in s^-2.
 
-``ω = √v``
+``ω = sign(v)√|v|``
 
 ``ν̃ = 1/(2π * c) * ω``
 
@@ -42,7 +42,7 @@ function wavenumber_eV(eigenvalues::Vector{Float64})
 
 	# Conversion eV Å^-2 g^-1 to s^-2: 
 	#   96485.307499 J/eV * 10^20 Å^2 / m^2 * 1000 g / kg)
-	omega = sqrt.(eigenvalues * 96485.307499 * 1.0E23)
+	omega = signed_sqrt(eigenvalues * 96485.307499 * 1.0E23)
 
 	# Convert wavenumbers in s^-2 to wavenumbers in cm^-1 : 1/(2π * c) * ω
 	wavenumbers = 1 / (2π * 2.99792458e10) * omega
@@ -56,7 +56,7 @@ end
 Convert `eigenvalues` from kcal Å^-2 g^-1 to `wavenumbers` in cm^-1. Made for QMCFC hessian files.
 Output include `omega` in s^-2.
 
-``ω = √v``
+``ω = sign(v)√|v|``
 
 ``ν̃ = 1/(2π * c) * ω``
 
@@ -67,12 +67,16 @@ function wavenumber_kcal(eigenvalues::Vector{Float64})
 
 	# Convert eigenvalues in kcal Å^-2 g^-1 to wavenumbers in s^-2: 
 	#   4184 * 10^23 (4184 J/kcal * 10^20 Å^2 / m^2 * 1000 g / kg)
-	omega = sqrt.(eigenvalues * 4184.0 * 1.0E23)
+	omega = signed_sqrt(eigenvalues * 4184.0 * 1.0E23)
 
 	# Convert wavenumbers in s^-2 to wavenumbers in cm^-1 : 1/(2π * c) * ω
 	wavenumbers = 1 / (2π * 2.99792458e10) * omega
 
 	return wavenumbers, omega
+end
+
+function signed_sqrt(values::Vector{Float64})
+	return sign.(values) .* sqrt.(abs.(values))
 end
 
 """

--- a/src/symmetrize.jl
+++ b/src/symmetrize.jl
@@ -40,20 +40,23 @@ function symmetrize_multiplication(hessian::Matrix{Float64})
 end
 
 """
-	mass_weight_hessian(hessian, atom_masses)
+	mass_weighted_hessian(hessian, atom_masses; sign = 1.0)
 
-Mass weight a Hessian matrix using matrix multiplication for symmetrization.
+Mass weight a Hessian matrix using symmetric averaging.
 
 # Arguments
 - `hessian::Matrix{Float64}`: The Hessian matrix.
 - `atom_masses::Vector{Float64}`: The masses of the atoms.
 
+# Keyword Arguments
+- `sign::Real`: Sign convention for the input Hessian. Use `-1` for force-derivative Hessians.
+
 # Returns
 - `hessian::Matrix{Float64}`: The mass weighted Hessian matrix.
 """
-function mass_weighted_hessian(hessian::Matrix{Float64}, atom_masses::Vector{Float64})
+function mass_weighted_hessian(hessian::Matrix{Float64}, atom_masses::Vector{Float64}; sign::Real = 1.0)
 	# Symmetrize the hessian
-	hessian = symmetrize_multiplication(hessian)
+	hessian = symmetrize_addition(Float64(sign) * hessian)
 
 	# Get masses matrix
 	_masses_matrix = masses_matrix(atom_masses)
@@ -65,7 +68,7 @@ function mass_weighted_hessian(hessian::Matrix{Float64}, atom_masses::Vector{Flo
 end
 
 """
-	mass_weight_hessian_add(hessian, atom_masses)
+	mass_weighted_hessian_add(hessian, atom_masses)
 
 Mass weight a Hessian matrix using symmetrize by addition.
 

--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -1,3 +1,5 @@
+const LINEAR_ROTATION_RTOL = 1e-6
+
 """
 	translational_modes(atom_masses)
 	
@@ -56,8 +58,15 @@ function rotational_modes(atom_coords::Matrix{Float64}, atom_masses::Vector{Floa
 	rotation[:, 2] += ((P[:, 3]*X[1, :]'.-P[:, 1]*X[3, :]').*sqrt.(atom_masses))[:]
 	rotation[:, 3] += ((P[:, 1]*X[2, :]'.-P[:, 2]*X[1, :]').*sqrt.(atom_masses))[:]
 
-	# Normalize the rotation matrix
-	rotation = rotation ./ sqrt.(sum(rotation .^ 2, dims = 1))
+	# Normalize only non-zero rotations. Linear molecules have two rotations.
+	rotation_norms = sqrt.(sum(rotation .^ 2, dims = 1))[:]
+	threshold = LINEAR_ROTATION_RTOL * max(1.0, maximum(rotation_norms))
+	keep = rotation_norms .> threshold
+	rotation = rotation[:, keep]
+
+	if !isempty(rotation_norms[keep])
+		rotation = rotation ./ rotation_norms[keep]'
+	end
 
 	return rotation
 end
@@ -75,20 +84,40 @@ Calculate the transformation matrix.
 - `transformation::Matrix{Float64}`: The transformation matrix.
 """
 function transformation_matrix(atom_coords::Matrix{Float64}, atom_masses::Vector{Float64})
-
-	# Initialize transformation matrix 3N x 6
-	transformation = zeros(size(atom_coords, 1) * 3, 6)
-
 	# Calculate the translational modes
 	translation = translational_modes(atom_masses)
 	# Calculate the rotational modes
 	rotation = rotational_modes(atom_coords, atom_masses)
 
 	# Combine the translational and rotational modes
-	transformation[:, 1:3] = translation
-	transformation[:, 4:6] = rotation
+	transformation = hcat(translation, rotation)
 
 	return transformation
+end
+
+"""
+	internal_subspace(atom_coords, atom_masses)
+
+Calculate the orthonormal complement of the translational and rotational modes.
+
+# Arguments
+- `atom_coords::Matrix{Float64}`: The coordinates of the atoms.
+- `atom_masses::Vector{Float64}`: The masses of the atoms.
+
+# Returns
+- `subspace::Matrix{Float64}`: The internal-coordinate basis.
+"""
+function internal_subspace(atom_coords::Matrix{Float64}, atom_masses::Vector{Float64})
+	transformation = transformation_matrix(atom_coords, atom_masses)
+	total_modes = size(atom_coords, 1) * 3
+	external_modes = size(transformation, 2)
+
+	if external_modes >= total_modes
+		return zeros(total_modes, 0)
+	end
+
+	q = qr(transformation).Q
+	return Matrix(q[:, (external_modes + 1):total_modes])
 end
 
 """
@@ -115,7 +144,7 @@ function internal_coordinates(atom_coords::Matrix{Float64}, atom_masses::Vector{
 	# Calculate the hessian in internal coordinates
 	internal_hessian = transformation' * hessian_mw * transformation
 	# Calculate the eigenvalues and eigenvectors of the hessian in internal coordinates
-	eigenvalues, eigenvectors = eigen(internal_hessian)
+	eigenvalues, eigenvectors = eigen(Symmetric(internal_hessian))
 
 	# Calculate the masses matrix
 	masses_matrix = diagm(0 => [1 / sqrt(i) for i in atom_masses for j in 1:3])

--- a/src/write.jl
+++ b/src/write.jl
@@ -131,6 +131,15 @@ function write_calculate_output(wavenumbers, intensities; filename = nothing)
 end
 
 """
+	write_wavenumber_intensity(wavenumbers, intensities; filename = stdout)
+
+Write the wavenumbers and intensities to a file.
+"""
+function write_wavenumber_intensity(wavenumbers, intensities; filename = nothing)
+	return write_calculate_output(wavenumbers, intensities, filename = filename)
+end
+
+"""
 	write_calculate_output(wavenumbers, intensities, force_constants, reduced_masses; filename = stdout)
 
 Write the wavenumbers, intensities, force constants and reduced masses to a file.

--- a/test/calculate.jl
+++ b/test/calculate.jl
@@ -1,21 +1,90 @@
+using LinearAlgebra
+using VibrationalAnalysis: hessian_sign_factor, internal_subspace
+
 @testset "Read Files and Calculate VibAnal" begin
 	atom_names, atom_masses, atom_coords, atom_types = read_rst("data/test_h2o.rst")
 	hessian = read_hessian("data/test_hessian_h2o.dat")
 	atom_charges = read_moldescriptor("data/test_moldescriptor.dat", atom_names, atom_types)
 	wavenumbers, intensities, force_constants, reduced_masses = calculate(atom_masses, atom_coords, atom_charges, hessian)
-	@test wavenumbers[7:end] ≈ [1492.5104569439752, 3669.03923547886, 3784.390612155495] atol = 1e-5 rtol = 1e-8
-	@test intensities[7:end] ≈ [150.52494226058752, 86.42940396506292, 164.0700800418807] atol = 1e-5 rtol = 1e-8
-	@test force_constants[7:end] ≈ [1.4173086016921352, 8.312559679465139, 9.171054294242243] atol = 1e-5 rtol = 1e-8
-	@test reduced_masses[7:end] ≈ [1.0798645051916647, 1.0480202469197442, 1.086843369500246] atol = 1e-5 rtol = 1e-8
+	@test wavenumbers[7:end] ≈ [1492.5348853402552, 3669.024005934286, 3784.327469724926] atol = 1e-5 rtol = 1e-8
+	@test intensities[7:end] ≈ [150.5208654923484, 86.4334793788946, 164.08630456843233] atol = 1e-5 rtol = 1e-8
+	@test force_constants[7:end] ≈ [1.417347274653204, 8.312499126458267, 9.170834256960058] atol = 1e-5 rtol = 1e-8
+	@test reduced_masses[7:end] ≈ [1.079858621514245, 1.0480213128861526, 1.086853561248339] atol = 1e-5 rtol = 1e-8
 end
 
 @testset "Read Files and Calculate VibAnal - No Intensities" begin
 	atom_names, atom_masses, atom_coords, atom_types = read_rst("data/test_h2o.rst")
 	hessian = read_hessian("data/test_hessian_h2o.dat")
 	wavenumbers, force_constants, reduced_masses = calculate(atom_masses, atom_coords, hessian)
-	@test wavenumbers[7:end] ≈ [1492.5104569439752, 3669.03923547886, 3784.390612155495] atol = 1e-5 rtol = 1e-8
-	@test force_constants[7:end] ≈ [1.4173086016921352, 8.312559679465139, 9.171054294242243] atol = 1e-5 rtol = 1e-8
-	@test reduced_masses[7:end] ≈ [1.0798645051916647, 1.0480202469197442, 1.086843369500246] atol = 1e-5 rtol = 1e-8
+	@test wavenumbers[7:end] ≈ [1492.5348853402552, 3669.024005934286, 3784.327469724926] atol = 1e-5 rtol = 1e-8
+	@test force_constants[7:end] ≈ [1.417347274653204, 8.312499126458267, 9.170834256960058] atol = 1e-5 rtol = 1e-8
+	@test reduced_masses[7:end] ≈ [1.079858621514245, 1.0480213128861526, 1.086853561248339] atol = 1e-5 rtol = 1e-8
+end
+
+@testset "Linear molecule calculation" begin
+	atom_masses = [1.0, 1.0]
+	atom_coords = [0.0 0.0 -0.37; 0.0 0.0 0.37]
+	hessian = Matrix{Float64}(I, 6, 6)
+	wavenumbers, force_constants, reduced_masses, modes = calculate(atom_masses, atom_coords, hessian, hessian_sign = :positive)
+	@test size(modes) == (6, 6)
+	@test length(wavenumbers) == 6
+	@test length(force_constants) == 6
+	@test length(reduced_masses) == 6
+	@test all(isfinite, wavenumbers)
+	@test all(isfinite, force_constants)
+	@test all(isfinite, reduced_masses)
+	@test all(isfinite, modes)
+end
+
+@testset "CO2 linear and near-linear calculation" begin
+	atom_masses = [15.9994, 12.0107, 15.9994]
+	hessian = Matrix{Float64}(I, 9, 9)
+
+	for atom_coords in (
+		[-1.16 0.0 0.0; 0.0 0.0 0.0; 1.16 0.0 0.0],
+		[-1.16 0.0 0.0; 0.0 0.0 1e-6; 1.16 0.0 0.0],
+		[-1.16 0.0 1e-6; 0.0 0.0 0.0; 1.16 0.0 0.0],
+		[-1.16 0.0 0.0; 0.0 0.0 1e-5; 1.16 0.0 0.0],
+	)
+		wavenumbers, force_constants, reduced_masses, modes = calculate(atom_masses, atom_coords, hessian, hessian_sign = :positive)
+		@test size(modes) == (9, 9)
+		@test length(wavenumbers) == 9
+		@test length(force_constants) == 9
+		@test length(reduced_masses) == 9
+		@test all(isfinite, wavenumbers)
+		@test all(isfinite, force_constants)
+		@test all(isfinite, reduced_masses)
+		@test all(isfinite, modes)
+	end
+end
+
+@testset "Hessian sign convention" begin
+	atom_masses = [1.0, 1.0]
+	atom_coords = [0.0 0.0 -0.37; 0.0 0.0 0.37]
+	hessian = -Matrix{Float64}(I, 6, 6)
+	auto_wavenumbers, _, _, _ = calculate(atom_masses, atom_coords, hessian)
+	positive_wavenumbers, _, _, _ = calculate(atom_masses, atom_coords, hessian, hessian_sign = :positive)
+	negative_wavenumbers, _, _, _ = calculate(atom_masses, atom_coords, -hessian, hessian_sign = :negative)
+	numeric_wavenumbers, _, _, _ = calculate(atom_masses, atom_coords, hessian, hessian_sign = -1)
+	@test all(isfinite, auto_wavenumbers)
+	@test all(isfinite, positive_wavenumbers)
+	@test all(isfinite, negative_wavenumbers)
+	@test all(isfinite, numeric_wavenumbers)
+	@test all(>=(0), auto_wavenumbers)
+	@test any(<(0), positive_wavenumbers)
+	@test any(<(0), negative_wavenumbers)
+	@test all(>=(0), numeric_wavenumbers)
+	@test_throws ArgumentError calculate(atom_masses, atom_coords, hessian, hessian_sign = :invalid)
+
+	single_atom_wavenumbers, _, _, single_atom_modes = calculate([1.0], [0.0 0.0 0.0], Matrix{Float64}(I, 3, 3))
+	@test size(single_atom_modes) == (3, 3)
+	@test all(isfinite, single_atom_wavenumbers)
+
+	triatomic_coords = [0.0 0.0 0.0; 0.0 0.0 1.0; 0.0 1.0 0.0]
+	triatomic_masses = [1.0, 1.0, 1.0]
+	subspace = internal_subspace(triatomic_coords, triatomic_masses)
+	tie_hessian = subspace * Diagonal([-2.0, 1.0, 0.0]) * subspace'
+	@test hessian_sign_factor(triatomic_coords, triatomic_masses, tie_hessian, :auto) == -1.0
 end
 
 @testset "Normal Modes - H2O" begin
@@ -31,5 +100,6 @@ end
 	hessian = read_hessian("data/meoh_compare/hessian.dat")
 	_, _, _, eigenvectors_internal_normalized = calculate(atom_masses, atom_coords, hessian)
 	test_modes = hcat(map(row -> parse.(Float64, row), split.(readlines("data/meoh_compare/meoh_normal_modes.dat")))...)'
-	@test abs.(eigenvectors_internal_normalized[:, 7:end]) ≈ abs.(test_modes[:, 7:end]) atol = 1e-5
+	mode_diffs = abs.(abs.(eigenvectors_internal_normalized[:, 7:end]) .- abs.(test_modes[:, 7:end]))
+	@test maximum(mode_diffs) <= 1.1e-4
 end

--- a/test/observables.jl
+++ b/test/observables.jl
@@ -19,6 +19,14 @@ end
     @test omega ≈ [2.0455e13] rtol=1e-4 
 end
 
+@testset "Wave Number signed modes" begin
+    wavenumber, omega = wavenumber_kcal([-1.0, 0.0, 1.0])
+    @test wavenumber ≈ [-108.5914, 0.0, 108.5914] atol=1e-4
+    @test omega[1] < 0.0
+    @test omega[2] == 0.0
+    @test omega[3] > 0.0
+end
+
 @testset "Reduced Mass" begin
     @test reduced_mass([1.0, 2.0, 3.0]) == [1.0, 4.0, 9.0]
 end

--- a/test/symmetrize.jl
+++ b/test/symmetrize.jl
@@ -1,5 +1,6 @@
 using VibrationalAnalysis: symmetrize_addition, symmetrize_multiplication, read_hessian, read_rst, mass_weighted_hessian, mass_weighted_hessian_add
 using Test
+using LinearAlgebra
 
 # Test symmetrize matrices src/symmetrize.jl
 
@@ -23,10 +24,15 @@ end
         mass_weight_hessian = mass_weighted_hessian(hessian, atom_masses)
         @test mass_weight_hessian isa Matrix{Float64}
 
-        # Test Symmetrize Multiplication
+        # Test default symmetric averaging
         hessian = [4.0 2.0 0.5; 2.0 4.0 0.0; 0.5 0.0 4.0]
         atom_masses = [2.0]
         @test mass_weighted_hessian(hessian, atom_masses) ≈ [2.0 1.0 0.25; 1.0 2.0 0.0; 0.25 0.0 2.0] atol=1e-5
         @test mass_weighted_hessian_add(hessian, atom_masses) == [2.0 1.0 0.25; 1.0 2.0 0.0; 0.25 0.0 2.0] 
+
+        # Preserve Hessian sign instead of replacing it with sqrt(H' * H)
+        hessian = diagm(0 => [-4.0, 2.0, 8.0])
+        @test eigvals(mass_weighted_hessian(hessian, [1.0])) ≈ [-4.0, 2.0, 8.0]
+        @test eigvals(mass_weighted_hessian(hessian, [1.0], sign = -1.0)) ≈ [-8.0, -2.0, 4.0]
 
 end

--- a/test/transformation.jl
+++ b/test/transformation.jl
@@ -1,4 +1,4 @@
-using VibrationalAnalysis: translational_modes, rotational_modes, transformation_matrix, internal_coordinates
+using VibrationalAnalysis: translational_modes, rotational_modes, transformation_matrix, internal_subspace, internal_coordinates
 using Test
 using LinearAlgebra
 
@@ -17,6 +17,46 @@ using LinearAlgebra
 		0.0 0.5773502691896258 0.0
 		0.0 0.0 0.5773502691896258
 	]
+end
+
+@testset "Linear molecule rotations" begin
+	atom_coords = [0.0 0.0 -0.37; 0.0 0.0 0.37]
+	atom_masses = [1.0, 1.0]
+	rotation = rotational_modes(atom_coords, atom_masses)
+	transformation = transformation_matrix(atom_coords, atom_masses)
+	subspace = internal_subspace(atom_coords, atom_masses)
+	@test size(rotation) == (6, 2)
+	@test size(transformation) == (6, 5)
+	@test size(subspace) == (6, 1)
+	@test all(isfinite, rotation)
+	@test all(isfinite, transformation)
+	@test all(isfinite, subspace)
+end
+
+@testset "CO2 linear and near-linear rotations" begin
+	atom_masses = [15.9994, 12.0107, 15.9994]
+
+	linear_coords = [-1.16 0.0 0.0; 0.0 0.0 0.0; 1.16 0.0 0.0]
+	for atom_coords in (
+		linear_coords,
+		[-1.16 0.0 0.0; 0.0 0.0 1e-6; 1.16 0.0 0.0],
+		[-1.16 0.0 1e-6; 0.0 0.0 0.0; 1.16 0.0 0.0],
+	)
+		rotation = rotational_modes(atom_coords, atom_masses)
+		transformation = transformation_matrix(atom_coords, atom_masses)
+		subspace = internal_subspace(atom_coords, atom_masses)
+		@test size(rotation) == (9, 2)
+		@test size(transformation) == (9, 5)
+		@test size(subspace) == (9, 4)
+		@test all(isfinite, rotation)
+		@test all(isfinite, transformation)
+		@test all(isfinite, subspace)
+	end
+
+	bent_coords = [-1.16 0.0 0.0; 0.0 0.0 1e-5; 1.16 0.0 0.0]
+	@test size(rotational_modes(bent_coords, atom_masses)) == (9, 3)
+	@test size(transformation_matrix(bent_coords, atom_masses)) == (9, 6)
+	@test size(internal_subspace(bent_coords, atom_masses)) == (9, 3)
 end
 
 @testset "Rotational Modes" begin

--- a/test/write.jl
+++ b/test/write.jl
@@ -72,6 +72,13 @@ end
 		@test wavenumbers_test[2] == test_string[2]
 		@test wavenumbers_test[3] == test_string[3]
 		@test wavenumbers_test[4] == test_string[4]
+
+		write_wavenumber_intensity(wavenumbers, intensities, filename = "test_wavenumber_intensity.dat")
+		wavenumbers_test = readlines("test_wavenumber_intensity.dat")
+		@test wavenumbers_test[1] == test_string[1]
+		@test wavenumbers_test[2] == test_string[2]
+		@test wavenumbers_test[3] == test_string[3]
+		@test wavenumbers_test[4] == test_string[4]
 	end
 end
 


### PR DESCRIPTION
## Summary
- Preserve Hessian sign information by using symmetric averaging for default mass weighting, with `hessian_sign` auto/override support.
- Handle linear and near-linear molecules by dropping numerically zero rotational modes before normalization, including CO2 geometries with up to `1e-6` Å coordinate noise.
- Return signed wavenumbers for negative eigenvalues instead of `NaN`, and restore the exported `write_wavenumber_intensity` helper.

## Validation
- `/Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.test()'`\n- `/Users/jog/.juliaup/bin/julia +1.10 --project=. --color=yes -e 'import Pkg; Pkg.test()'`\n- `/Users/jog/.juliaup/bin/julia +1.10 --project=. --color=yes -e 'import Pkg; Pkg.test(coverage=true)'`\n- `/Users/jog/.juliaup/bin/julia --project=docs --color=yes docs/make.jl`\n- Python SciPy/ASE-units cross-check against corrected fixture values: max absolute differences `2.27e-12`, `4.55e-13`, and `1.51e-11` cm^-1 for the H2O/unit, H2O/compare, and MeOH fixtures.