### PR TITLE
Fix documentation deployment auth

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,6 +24,5 @@ jobs:
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
## Summary
- Stop passing DOCUMENTER_KEY to the documentation workflow so Documenter uses the workflow GITHUB_TOKEN publishing path.
- Keep contents: write permission for publishing generated docs to gh-pages.

## Validation
- /Users/jog/.juliaup/bin/julia --project=docs --color=yes docs/make.jl
- git diff --check

## Context
The main documentation failure reached deploydocs, then tried to fetch git@github.com:MolarVerse/VibrationalAnalysis.jl.git and failed because the SSH deploy key path was selected. The docs build itself passes locally.