### PR TITLE
Refresh TagBot workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,26 +6,17 @@ on:
   workflow_dispatch:
     inputs:
       lookback:
-        default: 3
+        description: "[DEPRECATED] No longer has any effect"
+        default: "3"
 permissions:
-  actions: read
-  checks: read
   contents: write
-  deployments: read
   issues: read
-  discussions: read
-  packages: read
-  pages: read
   pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1.18.1
+      - uses: JuliaRegistries/TagBot@v1.25.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary
- Update TagBot from v1.18.1 to v1.25.7.
- Remove the unusable SSH deploy-key input because this repository has no deploy keys configured.
- Trim TagBot permissions to the writes/reads it needs.
- Remove the stale CI push trigger for the deleted develop branch.

## Validation
- YAML parsed with Ruby YAML.load_file for TagBot and CI workflows.
- git diff --check