### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,11 +9,11 @@ authors:
   family-names: Gamper
   given-names: Jakob
   orcid: 0000-0003-1136-2536
-date-released: '2024-03-18'
+date-released: '2026-06-09'
 doi: 10.5281/zenodo.10829271
 license:
 - mit
 title: VibrationalAnalysis.jl
 type: software
-version: 0.1.5
+version: 0.3.2
 url: https://github.com/MolarVerse/VibrationalAnalysis.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VibrationalAnalysis"
 uuid = "04082e5c-1d57-4577-9a0f-61e6cd56dade"
 authors = ["Josef M. Gallmetzer"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"


### PR DESCRIPTION
## Summary
- Bump package version from 0.3.1 to 0.3.2.
- Update citation metadata to match the release version and date.

## Validation
- /Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.TOML.parsefile("Project.toml"); println("ok Project.toml")'
- ruby -e 'require "yaml"; YAML.load_file("CITATION.cff"); puts "ok CITATION.cff"'
- /Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.test()'
- git diff --check