### PR TITLE
Set Julia compatibility lower bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 Comonicon = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Summary
- Set the Julia compatibility lower bound to 1.10.
- Align package metadata with the Julia versions covered by CI.
- Fix the General registry automerge failure caused by testing the package on Julia 1.1.1.

## Validation
- /Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.TOML.parsefile("Project.toml"); println("ok Project.toml")'
- /Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.test()'
- git diff --check