### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,5 +15,5 @@ license:
 - mit
 title: VibrationalAnalysis.jl
 type: software
-version: 0.3.2
+version: 0.3.3
 url: https://github.com/MolarVerse/VibrationalAnalysis.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VibrationalAnalysis"
 uuid = "04082e5c-1d57-4577-9a0f-61e6cd56dade"
 authors = ["Josef M. Gallmetzer"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"


### PR DESCRIPTION
## Summary
- Bump package and citation metadata from 0.3.2 to 0.3.3.
- Release the corrected Julia compatibility lower bound already on main.

## Context
- v0.3.2 registered before the Julia compat correction reached the registry.
- v0.3.3 should publish the corrected metadata with julia = 1.10.

## Validation
- /Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.TOML.parsefile("Project.toml"); println("ok Project.toml")'
- ruby -e 'require "yaml"; YAML.load_file("CITATION.cff"); puts "ok CITATION.cff"'
- /Users/jog/.juliaup/bin/julia --project=. --color=yes -e 'import Pkg; Pkg.test()'
- git diff --check